### PR TITLE
Fix typos and cleanup events

### DIFF
--- a/src/components/ExperienceSection.tsx
+++ b/src/components/ExperienceSection.tsx
@@ -30,7 +30,7 @@ export const ExperienceSection: React.FC = () => {
       title: "Battery Management System Responsible Engineer",
       company: "Yellowjacket Space Program",
       period: "January 2025 - Present",
-      description: "Layout and schematic design of a 4-layer PCB intended for power management, including Buck/Boost Converters, Load Switches, LDOs, MOSFETs, Op-Amps, and Microcontrollers. Revised 6-layer PCB utilizing similar strucutre."
+      description: "Layout and schematic design of a 4-layer PCB intended for power management, including Buck/Boost converters, load switches, LDOs, MOSFETs, op-amps, and microcontrollers. Revised a 6-layer PCB utilizing a similar structure."
     }
   ];
 
@@ -46,7 +46,7 @@ export const ExperienceSection: React.FC = () => {
         {experiences.map((exp, index) => (
           <div key={index} className="relative">
             {/* Timeline connector */}
-            {index < experiences.length && (
+            {index < experiences.length - 1 && (
               <div className="absolute left-8 top-14 w-1 h-[calc(100%-3.5rem)] bg-gradient-to-b from-purple-400 to-fuchsia-500"></div>
             )}
             

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -42,7 +42,7 @@ export const Footer: React.FC = () => {
         <div className="h-px bg-zinc-800 my-6"></div>
         
         <div className="text-center text-gray-600 text-sm">
-          © {currentYear} Your Name. All rights reserved.
+          © {currentYear} Pratham Ingale. All rights reserved.
         </div>
       </div>
     </footer>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,17 +13,20 @@ export const Layout: React.FC<LayoutProps> = ({ children }) => {
 
   useEffect(() => {
     // For smooth scrolling
-    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
-      anchor.addEventListener('click', function (e) {
-        e.preventDefault();
-        const href = this.getAttribute('href');
-        if (href) {
-          document.querySelector(href)?.scrollIntoView({
-            behavior: 'smooth'
-          });
-        }
-      });
-    });
+    const anchors = Array.from(document.querySelectorAll('a[href^="#"]'));
+    const handleClick = function (this: HTMLAnchorElement, e: Event) {
+      e.preventDefault();
+      const href = this.getAttribute('href');
+      if (href) {
+        document.querySelector(href)?.scrollIntoView({ behavior: 'smooth' });
+      }
+    };
+
+    anchors.forEach(anchor => anchor.addEventListener('click', handleClick));
+
+    return () => {
+      anchors.forEach(anchor => anchor.removeEventListener('click', handleClick));
+    };
   }, []);
 
   return (

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -26,7 +26,7 @@ const About = () => {
             <div className="flex flex-col justify-center">
               <h2 className="text-2xl font-bold text-white mb-4">Hello, I'm Pratham Ingale</h2>
               <p className="text-gray-300 mb-4">
-                I'm an electrical engineering student at Georgia Tech with a passion for building real, test-ready hardware—especially in avionics, power electronics, and embedded systems. I thrive on turning schematics into tangilbe boards, debugging systems under pressure, and designing hardware that works.
+                I'm an electrical engineering student at Georgia Tech with a passion for building real, test-ready hardware—especially in avionics, power electronics, and embedded systems. I thrive on turning schematics into tangible boards, debugging systems under pressure, and designing hardware that works.
               </p>
               <p className="text-gray-300 mb-6">
                 Currently, I'm designing high reliability electronics through hands-on internships and leadership roles in student rocketry. From rocket BMS PCBs to DC-DC converters and HITL validation platforms, I'm focused on creating robust, efficient systems that can survive demanding environments.

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -165,7 +165,7 @@ const Resume = () => {
                       <li>Circuit Simulation (LTSpice, PSpice)</li>
                       <li>Soldering & Rework (SMD, THT, QFN, BGA)</li>
                       <li>DC-DC Converters (Buck, Boost, LDO)</li>
-                      <li>OScilloscopes, Logic Analyzers, Multimeters</li>
+                      <li>Oscilloscopes, Logic Analyzers, Multimeters</li>
                       <li>Harnessing, Signal Debug, HITL Testbeds</li>
                     </ul>
                   </div>


### PR DESCRIPTION
## Summary
- fix typos in About and Resume pages
- clarify hardware description in ExperienceSection
- only draw timeline connector when needed
- cleanup anchor event listeners in Layout
- update footer copyright

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684bcde7b6748322bfdaa66985376481